### PR TITLE
feat: Make Shift+Scroll for tab switching optional

### DIFF
--- a/WtProgram/GroupPlugins/MouseScrollPlugin.fs
+++ b/WtProgram/GroupPlugins/MouseScrollPlugin.fs
@@ -5,16 +5,21 @@ open System.Runtime.InteropServices
 type MouseScrollPlugin() as this =
     
     member this.wtGroup = Services.get<WindowGroup>()
+    member this.settings = Services.get<ISettings>()
 
     member this.onMouseLL(msg, pt, data:IntPtr) =
         match msg with
         | WindowMessages.WM_MOUSEWHEEL ->
             let wheelDelta = data.hiword
-            let doSwitch = 
-                if Win32Helper.IsKeyPressed(VirtualKeyCodes.VK_SHIFT) then
-                    this.wtGroup.isPointInGroup(pt)
+            let enableShiftScroll = this.settings.getValue("enableShiftScroll") :?> bool
+            let doSwitch =
+                if enableShiftScroll then
+                    if Win32Helper.IsKeyPressed(VirtualKeyCodes.VK_SHIFT) then
+                        this.wtGroup.isPointInGroup(pt)
+                    else
+                        this.wtGroup.isPointInTs(pt)
                 else
-                    this.wtGroup.isPointInTs(pt)
+                    this.wtGroup.isPointInGroup(pt) || this.wtGroup.isPointInTs(pt)
             if doSwitch then
                 let next = wheelDelta < int16(0)
                 this.wtGroup.switchWindow(next, true)

--- a/WtProgram/ManagerViewService/Views/BehaviorView.fs
+++ b/WtProgram/ManagerViewService/Views/BehaviorView.fs
@@ -17,10 +17,10 @@ type HotKeyView() =
                     with get() = unbox<'a>(Services.settings.getValue(name))
                     and set(value) = Services.settings.setValue(name, box(value))
         }
-        
+
     let resources = new ResourceManager("Properties.Resources", Assembly.GetExecutingAssembly());
 
-    let checkBox (prop:IProperty<bool>) = 
+    let checkBox (prop:IProperty<bool>) =
         let checkbox = BoolEditor() :> IPropEditor
         checkbox.value <- box(prop.value)
         checkbox.changed.Add <| fun() -> prop.value <- unbox<bool>(checkbox.value)
@@ -28,21 +28,21 @@ type HotKeyView() =
 
     let settingsCheckbox key = checkBox(settingsProperty(key))
 
-    let dropDown (prop:IProperty<string>, items: string list) = 
+    let dropDown (prop:IProperty<string>, items: string list) =
         let combo = new ComboBox()
 
         // First add items
         combo.Items.AddRange(items |> List.toArray |> Array.map box)
-        
+
         // Then set initial value if exists, otherwise select first item
-        let initialIndex = 
+        let initialIndex =
             match items |> List.tryFindIndex ((=) prop.value) with
             | Some index -> index
             | None -> if combo.Items.Count > 0 then 0 else -1
-        
+
         if initialIndex >= 0 then
             combo.SelectedIndex <- initialIndex
-            
+
         combo.SelectedIndexChanged.Add(fun _ ->
             if combo.SelectedIndex >= 0 then
                 prop.value <- combo.SelectedItem.ToString()
@@ -52,7 +52,7 @@ type HotKeyView() =
 
     let settingsDropDown key value = dropDown(settingsProperty(key), value)
 
-    let basicForm = 
+    let basicForm =
         let fields = List2([
             ("runAtStartup", settingsCheckbox "runAtStartup")
             ("hideInactiveTabs", settingsCheckbox "hideInactiveTabs")
@@ -62,7 +62,7 @@ type HotKeyView() =
         ])
         "Basics", UIHelper.form fields
 
-    let taskForm = 
+    let taskForm =
         let fields = List2([
             ("combineIconsInTaskbar", settingsCheckbox "combineIconsInTaskbar")
             ("replaceAltTab", settingsCheckbox "replaceAltTab")
@@ -97,6 +97,7 @@ type HotKeyView() =
         let fields = fields.prependList(List2([
             ("enableCtrlNumberHotKey", settingsCheckbox "enableCtrlNumberHotKey")
             ("enableHoverActivate", settingsCheckbox "enableHoverActivate")
+            ("enableShiftScroll", settingsCheckbox "enableShiftScroll") // Added this line
         ]))
 
         "Switch Tabs", UIHelper.form fields
@@ -107,7 +108,7 @@ type HotKeyView() =
         switchTabs
         ])
 
-    let table = 
+    let table =
         let font = Font(resources.GetString("Font"), 10f)
         let controls = sections.map <| fun(text,control) ->
             control.Dock <- DockStyle.Fill
@@ -127,4 +128,3 @@ type HotKeyView() =
         member x.key = SettingsViewType.HotKeySettings
         member x.title = resources.GetString("Behavior")
         member x.control = table :> Control
-

--- a/WtProgram/Settings.fs
+++ b/WtProgram/Settings.fs
@@ -131,6 +131,7 @@ type Settings(isStandAlone) as this =
                         enableCtrlNumberHotKey = settingsJson.getBool("enableCtrlNumberHotKey").def(true)
                         enableHoverActivate = settingsJson.getBool("enableHoverActivate").def(false)
                         autoHide = settingsJson.getBool("autoHide").def(true)
+                        enableShiftScroll = settingsJson.getBool("enableShiftScroll").def(true)
                         version = settingsJson.getString("version").def(String.Empty)
                         alignment = settingsJson.getString("alignment").def("Center")
                         tabAppearance =
@@ -177,6 +178,7 @@ type Settings(isStandAlone) as this =
             settingsJson.setBool("enableCtrlNumberHotKey", settings.enableCtrlNumberHotKey)
             settingsJson.setBool("enableHoverActivate", settings.enableHoverActivate)
             settingsJson.setBool("autoHide", settings.autoHide)
+            settingsJson.setBool("enableShiftScroll", settings.enableShiftScroll)
             settingsJson.setStringArray("includedPaths", settings.includedPaths.items)
             settingsJson.setStringArray("excludedPaths", settings.excludedPaths.items)
             settingsJson.setStringArray("autoGroupingPaths", settings.autoGroupingPaths.items)


### PR DESCRIPTION
This commit introduces a new setting, `enableShiftScroll`, that allows you to control the behavior of mouse wheel tab switching.

- When `enableShiftScroll` is `true` (the default), you must press the Shift key while scrolling the mouse wheel to switch tabs.
- When `enableShiftScroll` is `false`, you can switch tabs by scrolling the mouse wheel directly over the tab group or tab strip, without needing to press Shift.

Changes include:
- Added `enableShiftScroll` to `SettingsRec` in `WtProgram/Settings.fs`, defaulting to `true`.
- Updated settings serialization in `WtProgram/Settings.fs` to handle the new setting.
- Modified `WtProgram/GroupPlugins/MouseScrollPlugin.fs` to read the `enableShiftScroll` setting and adjust its behavior accordingly.
- Added a checkbox in the Behavior settings view (`WtProgram/ManagerViewService/Views/BehaviorView.fs`) to allow you to toggle this new setting. The checkbox label will be generated as "Enable Shift Scroll".