### PR TITLE
Add enableShiftScroll setting and related functionality

### DIFF
--- a/WtProgram/GroupPlugins/MouseScrollPlugin.fs
+++ b/WtProgram/GroupPlugins/MouseScrollPlugin.fs
@@ -5,13 +5,15 @@ open System.Runtime.InteropServices
 type MouseScrollPlugin() as this =
     
     member this.wtGroup = Services.get<WindowGroup>()
+    member this.settings = Services.get<ISettings>()
 
     member this.onMouseLL(msg, pt, data:IntPtr) =
         match msg with
         | WindowMessages.WM_MOUSEWHEEL ->
             let wheelDelta = data.hiword
-            let doSwitch = 
-                if Win32Helper.IsKeyPressed(VirtualKeyCodes.VK_SHIFT) then
+            let enableShiftScroll = this.settings.getValue("enableShiftScroll") :?> bool
+            let doSwitch =
+                if enableShiftScroll && Win32Helper.IsKeyPressed(VirtualKeyCodes.VK_SHIFT) then
                     this.wtGroup.isPointInGroup(pt)
                 else
                     this.wtGroup.isPointInTs(pt)

--- a/WtProgram/ManagerViewService/Views/BehaviorView.fs
+++ b/WtProgram/ManagerViewService/Views/BehaviorView.fs
@@ -1,4 +1,4 @@
-﻿namespace Bemo
+namespace Bemo
 open System
 open System.Drawing
 open System.IO
@@ -97,6 +97,7 @@ type HotKeyView() =
         let fields = fields.prependList(List2([
             ("enableCtrlNumberHotKey", settingsCheckbox "enableCtrlNumberHotKey")
             ("enableHoverActivate", settingsCheckbox "enableHoverActivate")
+            ("enableShiftScroll", settingsCheckbox "enableShiftScroll")
         ]))
 
         "Switch Tabs", UIHelper.form fields
@@ -127,4 +128,3 @@ type HotKeyView() =
         member x.key = SettingsViewType.HotKeySettings
         member x.title = resources.GetString("Behavior")
         member x.control = table :> Control
-

--- a/WtProgram/Properties/Resources.ja-JP.resx
+++ b/WtProgram/Properties/Resources.ja-JP.resx
@@ -168,6 +168,9 @@
   <data name="enableHoverActivate" xml:space="preserve">
     <value>マウスホバーでタブを有効にする</value>
   </data>
+  <data name="enableShiftScroll" xml:space="preserve">
+    <value>タブ切り替えに Shift+スクロール を使用可能にする</value>
+  </data>
   <data name="autoHide" xml:space="preserve">
     <value>最大化時にタブを自動的に隠す</value>
   </data>

--- a/WtProgram/Properties/Resources.resx
+++ b/WtProgram/Properties/Resources.resx
@@ -168,6 +168,9 @@
   <data name="enableHoverActivate" xml:space="preserve">
     <value>Enable mouse hover to activate tab</value>
   </data>
+  <data name="enableShiftScroll" xml:space="preserve">
+    <value>Enable Shift+Scroll to switch tabs</value>
+  </data>
   <data name="autoHide" xml:space="preserve">
     <value>Auto hide tab when maximized</value>
   </data>

--- a/WtProgram/Settings.fs
+++ b/WtProgram/Settings.fs
@@ -131,6 +131,7 @@ type Settings(isStandAlone) as this =
                         enableCtrlNumberHotKey = settingsJson.getBool("enableCtrlNumberHotKey").def(true)
                         enableHoverActivate = settingsJson.getBool("enableHoverActivate").def(false)
                         autoHide = settingsJson.getBool("autoHide").def(true)
+                        enableShiftScroll = settingsJson.getBool("enableShiftScroll").def(true)
                         version = settingsJson.getString("version").def(String.Empty)
                         alignment = settingsJson.getString("alignment").def("Center")
                         tabAppearance =
@@ -177,6 +178,7 @@ type Settings(isStandAlone) as this =
             settingsJson.setBool("enableCtrlNumberHotKey", settings.enableCtrlNumberHotKey)
             settingsJson.setBool("enableHoverActivate", settings.enableHoverActivate)
             settingsJson.setBool("autoHide", settings.autoHide)
+            settingsJson.setBool("enableShiftScroll", settings.enableShiftScroll)
             settingsJson.setStringArray("includedPaths", settings.includedPaths.items)
             settingsJson.setStringArray("excludedPaths", settings.excludedPaths.items)
             settingsJson.setStringArray("autoGroupingPaths", settings.autoGroupingPaths.items)

--- a/WtProgram/Shared/ProgramTypes.fs
+++ b/WtProgram/Shared/ProgramTypes.fs
@@ -33,6 +33,7 @@ type SettingsRec = {
     combineIconsInTaskbar: bool
     enableHoverActivate: bool
     autoHide: bool
+    enableShiftScroll: bool
     alignment: string
     }
 


### PR DESCRIPTION
This pr introduces a new setting, enableShiftScroll, that allows you to control the behavior of mouse wheel tab switching.

Changes include:

- Added enableShiftScroll to SettingsRec in WtProgram/Settings.fs, defaulting to true.
- Updated settings serialization in WtProgram/Settings.fs to handle the new setting.
- Modified WtProgram/GroupPlugins/MouseScrollPlugin.fs to read the enableShiftScroll setting and adjust its behavior - accordingly.
- Added a checkbox in the Behavior settings view (WtProgram/ManagerViewService/Views/BehaviorView.fs) to allow you to toggle - this new setting. The checkbox label will be generated as "Enable Shift Scroll".